### PR TITLE
Add API integration PRD

### DIFF
--- a/api-integration-prd.md
+++ b/api-integration-prd.md
@@ -1,0 +1,52 @@
+# External API Integration System - PRD
+
+## Executive Summary
+Design and implement a robust external API integration system that connects RepoGuard with third-party security scanning services and development tools.
+
+---
+
+## Epic: External API Integration Hub
+
+Build a comprehensive API integration system that enables seamless connectivity with external security scanners, code analysis tools, and development platforms to enhance RepoGuard's analysis capabilities.
+
+### User Story 1: Security Scanner API Integration
+**As a security-conscious developer,**  
+**I want RepoGuard to integrate with external vulnerability scanners,**  
+**so that I can get comprehensive security analysis beyond basic pattern matching.**
+
+**Acceptance Criteria:**
+- Integrate with at least 2 security scanning APIs (Snyk, GitHub Security)
+- Automatically trigger scans when code changes are detected
+- Parse and normalize results from different scanner formats
+- Cache scan results to avoid redundant API calls
+- Handle API rate limits and retry logic gracefully
+- Display unified security findings in reports
+
+### User Story 2: CI/CD Platform Integration  
+**As a DevOps engineer,**  
+**I want RepoGuard to send analysis results to our CI/CD pipeline,**  
+**so that quality gates can automatically pass or fail builds based on RepoGuard findings.**
+
+**Acceptance Criteria:**
+- Support webhook delivery to CI/CD platforms (Jenkins, GitHub Actions, GitLab)
+- Include structured analysis data in webhook payloads
+- Allow configuration of quality thresholds for build failures
+- Provide status badges and build status updates
+- Support custom webhook templates for different platforms
+- Include retry logic for webhook delivery failures
+
+---
+
+## Technical Specifications
+
+**Supported Integrations:**
+- Security: Snyk API, GitHub Security Advisory API
+- CI/CD: Jenkins webhooks, GitHub Actions, GitLab CI
+- Communication: Slack webhooks, Microsoft Teams
+- Monitoring: Prometheus metrics, DataDog events
+
+**API Management:**
+- Centralized API key management and rotation
+- Request/response logging for debugging
+- Rate limiting and quota management per service
+- Circuit breaker pattern for failing services


### PR DESCRIPTION
Add PRD for external API integration system.

Contains epic and user stories for third-party API integrations including security scanners and CI/CD platforms.

This tests n8n workflow processing of another PRD structure.